### PR TITLE
Unhandled exception on missing sensor property "lastMeasurement"

### DIFF
--- a/example.py
+++ b/example.py
@@ -19,11 +19,16 @@ async def main():
         print("Name:", station.name)
         print("Description:", station.description)
         print("Coordinates:", station.coordinates)
+        print("Model:", station.model)
 
         print("PM 2.5:", station.pm2_5)
         print("PM 10:", station.pm10)
 
         print("Temperature:", station.temperature)
+        print("Humidity:", station.humidity)
+        print("Pressure:", station.air_pressure)
+        print("Exposure:", station.exposure)
+
 
 
 if __name__ == "__main__":

--- a/example.py
+++ b/example.py
@@ -5,7 +5,7 @@ import aiohttp
 
 from opensensemap_api import OpenSenseMap
 
-SENSOR_ID = "5a528c40fa02ec000fe9058a"
+SENSOR_ID = "63b83dcc6795ba0007794c93"
 
 
 async def main():
@@ -20,15 +20,20 @@ async def main():
         print("Description:", station.description)
         print("Coordinates:", station.coordinates)
         print("Model:", station.model)
+        print("Exposure:", station.exposure)
 
+        print("PM 1.0:", station.pm1_0)
         print("PM 2.5:", station.pm2_5)
         print("PM 10:", station.pm10)
 
         print("Temperature:", station.temperature)
         print("Humidity:", station.humidity)
         print("Pressure:", station.air_pressure)
-        print("Exposure:", station.exposure)
-
+        print("Wind Speed:", station.wind_speed)
+        print("Wind Direction:", station.wind_direction)
+        print("Precipitation:", station.precipitation)
+        print("Illuminance:", station.illuminance)
+        print("UV Index:", station.uv)
 
 
 if __name__ == "__main__":

--- a/opensensemap_api/__init__.py
+++ b/opensensemap_api/__init__.py
@@ -77,10 +77,10 @@ class OpenSenseMap(object):
     def coordinates(self):
         """Return the coordinates of the station."""
         return self.data["currentLocation"]["coordinates"]
-        
+
     @property
     def exposure(self):
-        """ Return the exposure of the station."""
+        """Return the exposure of the station."""
         try:
             return self.data["exposure"]
         except KeyError:
@@ -88,7 +88,7 @@ class OpenSenseMap(object):
 
     @property
     def model(self):
-        """ Return the model of the station."""
+        """Return the model of the station."""
         try:
             return self.data["model"]
         except KeyError:
@@ -146,7 +146,9 @@ class OpenSenseMap(object):
                 value = [
                     entry["lastMeasurement"]["value"]
                     for entry in self.data["sensors"]
-                    if entry["title"] == title and "lastMeasurement" in entry
+                    if entry["title"] == title
+                    and "lastMeasurement" in entry
+                    and "value" in entry["lastMeasurement"]
                 ][0]
                 return value
             except (IndexError, TypeError):

--- a/opensensemap_api/__init__.py
+++ b/opensensemap_api/__init__.py
@@ -77,6 +77,22 @@ class OpenSenseMap(object):
     def coordinates(self):
         """Return the coordinates of the station."""
         return self.data["currentLocation"]["coordinates"]
+        
+    @property
+    def exposure(self):
+        """ Return the exposure of the station."""
+        try:
+            return self.data["exposure"]
+        except KeyError:
+            return None
+
+    @property
+    def model(self):
+        """ Return the model of the station."""
+        try:
+            return self.data["model"]
+        except KeyError:
+            return None
 
     @property
     def pm10(self):
@@ -106,7 +122,7 @@ class OpenSenseMap(object):
     @property
     def air_pressure(self):
         """Return the current air pressure of a station."""
-        return self.get_value("Air pressure")
+        return self.get_value("Pressure")
 
     @property
     def illuminance(self):
@@ -130,7 +146,7 @@ class OpenSenseMap(object):
                 value = [
                     entry["lastMeasurement"]["value"]
                     for entry in self.data["sensors"]
-                    if entry["title"] == title
+                    if entry["title"] == title and "lastMeasurement" in entry
                 ][0]
                 return value
             except (IndexError, TypeError):

--- a/opensensemap_api/__init__.py
+++ b/opensensemap_api/__init__.py
@@ -13,27 +13,38 @@ _INSTANCE = "https://api.opensensemap.org/boxes/{id}"
 
 _TITLES = {
     "Air pressure": (
+        "Pressure",
         "Luftdruck",
         "Ilmanpaine",
-    ),  # fi
+    ),
     "Humidity": (
         "rel. Luftfeuchte",
+        "rel. Humidity",
         "Ilmankosteus",
         "Kosteus",
-    ),  # fi
+    ),
     "Illuminance": (
         "Beleuchtungsstärke",
         "Valoisuus",
-        "Valaistuksen voimakkuus",  # fi
+        "Valaistuksen voimakkuus",
+        "Ambient Light",
     ),
     "Temperature": (
         "Temperatur",
         "Lämpötila",
-    ),  # fi
+    ),
     "UV": (
+        "UV Index",
         "UV-Intensität",
         "UV-säteily",
-    ),  # fi
+    ),
+    "Precipitation": (
+        "Rain",
+        "Regen",
+        "Niederschlag",
+    ),
+    "Wind Speed": ("Windgeschwindigkeit",),
+    "Wind Direction": ("Windrichtung",),
 }
 
 
@@ -105,6 +116,11 @@ class OpenSenseMap(object):
         return self.get_value("PM2.5")
 
     @property
+    def pm1_0(self):
+        """Return the particulate matter 1.0 value."""
+        return self.get_value("PM1.0")
+
+    @property
     def temperature(self):
         """Return the temperature of a station."""
         return self.get_value("Temperature")
@@ -139,6 +155,21 @@ class OpenSenseMap(object):
         """Return the current radioactivity value of a station."""
         return self.get_value("Radioactivity")
 
+    @property
+    def wind_speed(self):
+        """Return the current wind speed value of a station."""
+        return self.get_value("Wind Speed")
+
+    @property
+    def wind_direction(self):
+        """Return the current wind direction value of a station."""
+        return self.get_value("Wind Direction")
+
+    @property
+    def precipitation(self):
+        """Return the current precipitation value of a station."""
+        return self.get_value("Precipitation")
+
     def get_value(self, key):
         """Extract a value for a given key."""
         for title in _TITLES.get(key, ()) + (key,):
@@ -146,7 +177,7 @@ class OpenSenseMap(object):
                 value = [
                     entry["lastMeasurement"]["value"]
                     for entry in self.data["sensors"]
-                    if entry["title"] == title
+                    if entry["title"].casefold() == title.casefold()
                     and "lastMeasurement" in entry
                     and "value" in entry["lastMeasurement"]
                 ][0]

--- a/opensensemap_api/__init__.py
+++ b/opensensemap_api/__init__.py
@@ -12,7 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 _INSTANCE = "https://api.opensensemap.org/boxes/{id}"
 
 _TITLES = {
-    "Air pressure": (
+    "Air Pressure": (
         "Pressure",
         "Luftdruck",
         "Ilmanpaine",
@@ -138,7 +138,7 @@ class OpenSenseMap(object):
     @property
     def air_pressure(self):
         """Return the current air pressure of a station."""
-        return self.get_value("Pressure")
+        return self.get_value("Air Pressure")
 
     @property
     def illuminance(self):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as readme:
 
 setup(
     name="opensensemap-api",
-    version="0.3.1",
+    version="0.3.2",
     description="Python client for interacting with the openSenseMap API.",
     long_description=long_description,
     url="https://github.com/home-assistant-ecosystem/python-opensensemap-api",


### PR DESCRIPTION
Hi 👋, lib was not working for a sensor for me, so here is a fix proposal. 

```
File "opensensemap_api/__init__.py", line 84, in pm10
    return self.get_value("PM10")
           ^^^^^^^^^^^^^^^^^^^^^^
  File "opensensemap_api/__init__.py", line 130, in get_value
    value = [
            ^
  File "opensensemap_api/__init__.py", line 131, in <listcomp>
    entry["lastMeasurement"]["value"]
    ~~~~~^^^^^^^^^^^^^^^^^^^
KeyError: 'lastMeasurement'
```

How it looks as an API result (redacted some fields):
```json
{
  "name": "foo",
  "currentLocation": {},
  "exposure": "outdoor",
  "sensors": [
    {
      "icon": "osem-cloud",
      "title": "PM10",
      "unit": "ug/m^3",
      "sensorType": "SD011",
      "_id": "bar"
    }
  ],
  "model": "custom",
  "grouptag": [],
  "description": "",
  "loc": []
}
```

how this looks on opensensemap:
![image](https://github.com/home-assistant-ecosystem/python-opensensemap-api/assets/23377960/e57d3cbc-ae8d-4404-9cf7-ccb1fed27e71)


proposed fix:
https://github.com/home-assistant-ecosystem/python-opensensemap-api/pull/10/files#diff-71494bd9516705d7268abe1224ba49e58456191bb85485c4530dcdacfdde07beR180-R182

Boy scouting: 
- Tried to make some more API values (exposure, model) accessible.
- Tried to fix air pressure readings, they were also broken (always returning `None`) for me